### PR TITLE
Improve GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: [ubuntu-latest]
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
 
     steps:
       - name: Checkout Repo
@@ -31,13 +32,17 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}
+          key: cache-gradle-${{ runner.os }}-${{ hashFiles('checksum.txt') }}
+          restore-keys: |
+            cache-gradle-${{ runner.os }}-
+            cache-gradle-
 
       - name: Test Application
         run: ./gradlew check
 
   assemble:
     runs-on: [ubuntu-latest]
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
 
     steps:
       - name: Checkout Repo
@@ -60,7 +65,10 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}
+          key: cache-gradle-${{ runner.os }}-${{ hashFiles('checksum.txt') }}
+          restore-keys: |
+            cache-gradle-${{ runner.os }}-
+            cache-gradle-
 
       - name: Build Debug APK
         run: ./gradlew assembleDebug

--- a/checksum.sh
+++ b/checksum.sh
@@ -13,7 +13,7 @@ checksum_file() {
 FILES=()
 while read -r -d ''; do
 	FILES+=("$REPLY")
-done < <(find . -type f \( -name "build.gradle*" -o -name "app_config.gradle" -o -name "gradle-wrapper.properties" \) -print0)
+done < <(find . -type f \( -name "build.gradle*" -o -name "Dependencies.kt" -o -name "gradle-wrapper.properties" \) -print0)
 
 # Loop through files and append MD5 to result file
 for FILE in ${FILES[@]}; do


### PR DESCRIPTION
Improve GitHub workflows by doing the following:
- Configure better Gradle folders caching strategy
- Add the option to skip running CI jobs
- Provide the correct file containing libraries' dependencies inside checksum.sh for proper cache key generation