### PR TITLE
Downgrade Java version from 11 to 1.8

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,8 +25,8 @@ object appConfig {
     const val minSdkVersion = 21
     const val applicationId = "com.paulrybitskyi.commons.sample"
 
-    val javaCompatibilityVersion = JavaVersion.VERSION_11
-    val kotlinCompatibilityVersion = JavaVersion.VERSION_11
+    val javaCompatibilityVersion = JavaVersion.VERSION_1_8
+    val kotlinCompatibilityVersion = JavaVersion.VERSION_1_8
 }
 
 object versions {


### PR DESCRIPTION
Compiling libraries with Java 11 has major implications on end-users, who will have to bump their projects' Java version to 11 as well to be able to compile them. This is a major issue, since libraries, especially third-party ones, do not have impose such restrictions.